### PR TITLE
Revamped module unification to explain more clearly for newcomers

### DIFF
--- a/src/ui/components/roadmap-page/-utils/features.yaml
+++ b/src/ui/components/roadmap-page/-utils/features.yaml
@@ -132,37 +132,41 @@ features:
       - name: Edward Faulkner
         image: https://avatars0.githubusercontent.com/u/319282?v=4&s=460
         url: https://github.com/ef4
-  - name: Module Unification
+  - name: Improved File Layout ("New Pods" or "Module Unification")
     summary: |
-      Co-locate related parts of the framework such as templates,
-      components, and component tests with new filesystem layout.
+      Groups related files in Ember apps to ease access to commonly used files. This also lays the groundwork
+      for long-term improvements to numerous areas in Ember.
     description: |
-      Ember applications are compiled from JavaScript modules in the `app/` folder and addons.
-      The rules for how Ember finds a module for a given part of the system are coupled to the
-      implementation instead of any unified design.
-      
-      Module Unification describes a new way to lay out Ember applications and
-      addons in the `src/` directory.
-      This design allows us to co-locate related parts of the framework such as templates,
-      components, and component tests. It also creates smaller namespaces for components and
-      provides a pathway for addons to declare new types of modules. The rules for resolving
-      a Module Unification module are also much simpler than the existing rules, meaning
-      opportunities for better performance and compile-time optimizations.
+      The "New Pods" project (or "Module Unification") describes a new way to lay out Ember applications and
+      addons in the `src/` directory (switching away from the `app/` folder).
+
+      This new approach will replace both the traditional "classic" filesystem layout and also
+      "pods". Pods were an initial experiment from the very early days of Ember-CLI (when it too was an experiment)
+      Pods have been a huge success, but the initial experiment had some issues under-the-hood
+      that we're now able to improve upon based on what we've learned as a community.
+
+      This new design allows us to put related parts of the framework together such as templates,
+      components, and component tests. It also makes it possible for components to reference relative
+      components and provides the ability for addons to declare new module types.
+
+      As part of the rework here, the rules for "resolving" files become much simpler,
+      allowing for better app performance and compile-time optimizations. It also lays the ground work for
+      automated code-splitting work to occur (see further down the page).
     status: in-development
     statusText: In Implementation
     availability: Not yet available.
     resources:
       - type: blogpost
-        name: EmberCamp Module Unification Update
+        name: High-level overview
         url: https://madhatted.com/2017/7/12/embercamp-module-unification-update
       - type: doc
-        name: Coordination doc with relevant issues
-        url: https://docs.google.com/document/d/1P9q9K1JNadJclhFG0flUyY2GwKuOzTbgtUbOzuh6JYs/edit#heading=h.45ec702vuy8p
+        name: Work coordination document
+        url: https://paper.dropbox.com/doc/Module-Unification-Sync-Doc-1mmGPKnA1Rq8n4gMWaK8q
       - type: channel
-        name: "#st-module-unification"
+        name: 'Slack: #st-module-unification'
         url: https://embercommunity.slack.com
       - type: rfc
-        name: Module Unification
+        name: Module Unification RFC
         url: https://github.com/emberjs/rfcs/pull/143
     champions:
       - name: Matthew Beale


### PR DESCRIPTION
Goals here were to add a bit of info about "old pods" (and why we were replacing them) along with clarifying things a bit in user-facing English